### PR TITLE
Tag uploaded files one by one in the background

### DIFF
--- a/geoparser/annotator/annotator.py
+++ b/geoparser/annotator/annotator.py
@@ -48,6 +48,35 @@ class GeoparserAnnotator(Geoparser):
                 "spacy_applied": apply_spacy,
             }
 
+    def parse_doc(self, doc: dict) -> dict:
+        self.nlp = self.setup_spacy(doc["spacy_model"])
+        spacy_doc = self.nlp(doc["text"])
+        new_toponyms = [
+            {
+                "text": top.text,
+                "start": top.start_char,
+                "end": top.end_char,
+                "loc_id": "",  # Empty string indicates not annotated yet
+            }
+            for top in spacy_doc.toponyms
+        ]
+        toponyms = self.merge_toponyms(doc["toponyms"], new_toponyms)
+        doc["toponyms"] = toponyms
+        doc["spacy_applied"] = True
+        return doc
+
+    def merge_toponyms(
+        self, old_toponyms: list[dict], new_toponyms: list[dict]
+    ) -> list[dict]:
+        toponyms = []
+        for new_toponym in new_toponyms:
+            # only add the spacy-toponym if there is no existing one
+            if not self.get_toponym(
+                old_toponyms, new_toponym["start"], new_toponym["end"]
+            ):
+                toponyms.append(new_toponym)
+        return sorted(toponyms + old_toponyms, key=lambda x: x["start"])
+
     def get_pre_annotated_text(self, text: str, toponyms: dict[str, str]) -> str:
         html_parts = []
         last_idx = 0

--- a/geoparser/annotator/annotator.py
+++ b/geoparser/annotator/annotator.py
@@ -51,7 +51,7 @@ class GeoparserAnnotator(Geoparser):
     def parse_doc(self, doc: dict) -> dict:
         self.nlp = self.setup_spacy(doc["spacy_model"])
         spacy_doc = self.nlp(doc["text"])
-        new_toponyms = [
+        toponyms = [
             {
                 "text": top.text,
                 "start": top.start_char,
@@ -60,7 +60,6 @@ class GeoparserAnnotator(Geoparser):
             }
             for top in spacy_doc.toponyms
         ]
-        toponyms = self.merge_toponyms(doc["toponyms"], new_toponyms)
         doc["toponyms"] = toponyms
         doc["spacy_applied"] = True
         return doc

--- a/geoparser/annotator/annotator.py
+++ b/geoparser/annotator/annotator.py
@@ -20,26 +20,32 @@ class GeoparserAnnotator(Geoparser):
             None,
         )
 
-    def parse_files(self, files: list[t.IO], spacy_model: str) -> t.Iterator[dict]:
-        self.nlp = self.setup_spacy(spacy_model)
+    def parse_files(
+        self, files: list[t.IO], spacy_model: str, apply_spacy: bool = True
+    ) -> t.Iterator[dict]:
+        if apply_spacy:
+            self.nlp = self.setup_spacy(spacy_model)
         for file in files:
             filename = secure_filename(file.filename)
             text = file.read().decode("utf-8")
-            doc = self.nlp(text)
-            toponyms = [
-                {
-                    "text": top.text,
-                    "start": top.start_char,
-                    "end": top.end_char,
-                    "loc_id": "",  # Empty string indicates not annotated yet
-                }
-                for top in doc.toponyms
-            ]
+            toponyms = []
+            if apply_spacy:
+                doc = self.nlp(text)
+                toponyms = [
+                    {
+                        "text": top.text,
+                        "start": top.start_char,
+                        "end": top.end_char,
+                        "loc_id": "",  # Empty string indicates not annotated yet
+                    }
+                    for top in doc.toponyms
+                ]
             yield {
                 "filename": filename,
                 "spacy_model": spacy_model,
                 "text": text,
                 "toponyms": toponyms,
+                "spacy_applied": apply_spacy,
             }
 
     def get_pre_annotated_text(self, text: str, toponyms: dict[str, str]) -> str:

--- a/geoparser/annotator/app.py
+++ b/geoparser/annotator/app.py
@@ -233,10 +233,10 @@ def parse_document(session_id, doc_index):
     doc = session["documents"][doc_index]
     if not doc.get("spacy_applied"):
         doc = annotator.parse_doc(doc)
-        # reload toponyms in case the user has added some in the meantime
-        old_toponyms = sessions_cache.load(session_id)["documents"][doc_index][
-            "toponyms"
-        ]
+        # reload session in case there have been changes to it in the meantime
+        session = sessions_cache.load(session_id)
+        # merge toponyms in case the user has added some in the meantime
+        old_toponyms = session["documents"][doc_index]["toponyms"]
         spacy_toponyms = doc["toponyms"]
         doc["toponyms"] = annotator.merge_toponyms(old_toponyms, spacy_toponyms)
         # save parsed toponyms into session

--- a/geoparser/annotator/app.py
+++ b/geoparser/annotator/app.py
@@ -80,11 +80,6 @@ def annotate(session_id):
         return redirect(url_for("annotate", session_id=session_id, doc_index=0))
 
     doc = session["documents"][doc_index]
-    if not doc.get("spacy_applied"):
-        doc = annotator.parse_doc(doc)
-        # save parsed toponyms into session
-        session["documents"][doc_index] = doc
-        sessions_cache.save(session["session_id"], session)
 
     # Prepare pre-annotated text
     pre_annotated_text = annotator.get_pre_annotated_text(doc["text"], doc["toponyms"])
@@ -238,6 +233,27 @@ def get_document_progress(session_id, doc_index):
             "progress_percentage": progress_percentage,
         }
     )
+
+
+@app.post("/session/<session_id>/document/<doc_index>/parse")
+def parse_document(session_id, doc_index):
+    doc_index = int(doc_index)
+
+    session = sessions_cache.load(session_id)
+    if not session:
+        return jsonify({"message": "Session not found", "status": "error"}), 404
+
+    if doc_index >= len(session["documents"]):
+        return jsonify({"message": "Invalid document index", "status": "error"}), 422
+
+    doc = session["documents"][doc_index]
+    if not doc.get("spacy_applied"):
+        doc = annotator.parse_doc(doc)
+        # save parsed toponyms into session
+        session["documents"][doc_index] = doc
+        sessions_cache.save(session["session_id"], session)
+        return jsonify({"status": "success", "parsed": True})
+    return jsonify({"status": "success", "parsed": False})
 
 
 @app.get("/session/<session_id>/document/<doc_index>/text")

--- a/geoparser/annotator/app.py
+++ b/geoparser/annotator/app.py
@@ -209,6 +209,16 @@ def add_documents(session_id):
     return jsonify({"status": "success"})
 
 
+@app.get("/session/<session_id>/documents")
+def get_documents(session_id):
+    session = sessions_cache.load(session_id)
+    if not session:
+        return jsonify({"message": "Session not found.", "status": "error"}), 404
+
+    docs = session["documents"]
+    return jsonify(docs)
+
+
 @app.post("/session/<session_id>/document/<doc_index>/parse")
 def parse_document(session_id, doc_index):
     doc_index = int(doc_index)

--- a/geoparser/annotator/app.py
+++ b/geoparser/annotator/app.py
@@ -223,6 +223,12 @@ def parse_document(session_id, doc_index):
     doc = session["documents"][doc_index]
     if not doc.get("spacy_applied"):
         doc = annotator.parse_doc(doc)
+        # reload toponyms in case the user has added some in the meantime
+        old_toponyms = sessions_cache.load(session_id)["documents"][doc_index][
+            "toponyms"
+        ]
+        spacy_toponyms = doc["toponyms"]
+        doc["toponyms"] = annotator.merge_toponyms(old_toponyms, spacy_toponyms)
         # save parsed toponyms into session
         session["documents"][doc_index] = doc
         sessions_cache.save(session["session_id"], session)

--- a/geoparser/annotator/static/annotate.css
+++ b/geoparser/annotator/static/annotate.css
@@ -150,3 +150,18 @@ h2 {
     top: 50%;
     transform: translate(-50%, -50%);
 }
+.loader {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    border: 16px solid #f3f3f3; /* Light grey */
+    border-top: 16px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 120px;
+    height: 120px;
+    animation: spin 2s linear infinite;
+}
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/geoparser/annotator/static/annotate.js
+++ b/geoparser/annotator/static/annotate.js
@@ -49,6 +49,10 @@ document.addEventListener('DOMContentLoaded', function() {
     var oneSensePerDiscourseCheckbox = document.getElementById('one-sense-per-discourse');
     var autoCloseAnnotationModalCheckbox = document.getElementById('auto-close-annotation-modal');
 
+    // Toponym recognition indictaor
+    var toponymRecognitionIndicator = document.getElementById('toponym-recognition-indicator');
+    toponymRecognitionIndicator.style.display = "block";
+
     // Fetch session settings
     fetch(Flask.url_for("get_session_settings", {session_id: sessionId}), {
         method: 'GET',
@@ -79,6 +83,8 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(response => {
         if (response.status === 200) {
             reloadDocumentText();
+            // hide toponym recognition indicator
+            toponymRecognitionIndicator.style.display = "none";
         } else {
             alert('Failed to load settings.');
         }

--- a/geoparser/annotator/static/annotate.js
+++ b/geoparser/annotator/static/annotate.js
@@ -20,8 +20,11 @@ document.addEventListener('DOMContentLoaded', function() {
     var docIndex = Number(params.get("doc_index"));
     var progressBar = document.getElementById('progress-bar-' + docIndex);
 
-    // Get the document text container
+    // Get the document text container and load spinner
     var documentText = document.getElementById('document-text');
+    documentText.style.display = "none";
+    var taggingLoadSpinner = document.getElementById('toponym-recognition-indicator');
+    taggingLoadSpinner.style.display = "block";
 
     // Initialize totalTextLength
     var totalTextLength = documentText.textContent.length;
@@ -49,9 +52,6 @@ document.addEventListener('DOMContentLoaded', function() {
     var oneSensePerDiscourseCheckbox = document.getElementById('one-sense-per-discourse');
     var autoCloseAnnotationModalCheckbox = document.getElementById('auto-close-annotation-modal');
 
-    // Toponym recognition indictaor
-    var toponymRecognitionIndicator = document.getElementById('toponym-recognition-indicator');
-    toponymRecognitionIndicator.style.display = "block";
 
     // Fetch session settings
     fetch(Flask.url_for("get_session_settings", {session_id: sessionId}), {
@@ -83,8 +83,9 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(response => {
         if (response.status === 200) {
             reloadDocumentText();
-            // hide toponym recognition indicator
-            toponymRecognitionIndicator.style.display = "none";
+            // allow editing document
+            taggingLoadSpinner.style.display = "none";
+            documentText.style.display = "block";
         } else {
             alert('Failed to load settings.');
         }

--- a/geoparser/annotator/static/annotate.js
+++ b/geoparser/annotator/static/annotate.js
@@ -69,6 +69,21 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
+    // parse document with spacy
+    fetch(Flask.url_for("parse_document", {session_id: sessionId, doc_index: docIndex}), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(response => {
+        if (response.status === 200) {
+            reloadDocumentText();
+        } else {
+            alert('Failed to load settings.');
+        }
+    });
+
     settingsBtn.addEventListener('click', function() {
         // Load current settings from the server
         fetch(Flask.url_for("get_session_settings", {session_id: sessionId}), {

--- a/geoparser/annotator/templates/annotate.html
+++ b/geoparser/annotator/templates/annotate.html
@@ -110,9 +110,11 @@
 
         <!-- Main Content -->
         <div class="col-md-10" id="main-content">
-            <h2 class="mt-3">{{ doc.filename }}</h2>
-            <h2 class="mt-3" id="toponym-recognition-indicator">toponym recognition...</h2>
-            <div id="document-text">{{ pre_annotated_text | safe }}</div>
+          <div class="col-md-10" id="document-header">
+            <h2 class="mt-3" style="text-align:left;float:left;">{{ doc.filename }}</h2>
+            <h2 class="mt-3" style="text-align:left;float:left;font-style:italic;color:#696969" id="toponym-recognition-indicator">toponym recognition in progress...</h2>
+          </div>
+          <div id="document-text">{{ pre_annotated_text | safe }}</div>
         </div>
     </div>
 </div>

--- a/geoparser/annotator/templates/annotate.html
+++ b/geoparser/annotator/templates/annotate.html
@@ -111,6 +111,7 @@
         <!-- Main Content -->
         <div class="col-md-10" id="main-content">
             <h2 class="mt-3">{{ doc.filename }}</h2>
+            <h2 class="mt-3" id="toponym-recognition-indicator">toponym recognition...</h2>
             <div id="document-text">{{ pre_annotated_text | safe }}</div>
         </div>
     </div>

--- a/geoparser/annotator/templates/annotate.html
+++ b/geoparser/annotator/templates/annotate.html
@@ -59,6 +59,7 @@
                            style="text-decoration: none;">
                             {{ doc_item['filename'] }}
                         </a>
+                        <a id="tagged-{{ doc_item.doc_index }}" style="color:green;font-style:italic;display:none;">tagged &check;</a>
                         <!-- Remove Document Button -->
                         <button type="button" class="btn btn-sec btn-sm remove-document-btn" data-doc-index="{{ doc_item.doc_index }}" title="Remove Document">
                             <i class="bi bi-trash"></i>
@@ -113,8 +114,8 @@
           <div class="col-md-10" id="document-header">
             <h2 class="mt-3" style="text-align:left;float:left;">{{ doc.filename }}</h2>
           </div>
-          <div class="loader" id="toponym-recognition-indicator"></div>
-          <div id="document-text">{{ pre_annotated_text | safe }}</div>
+          <div class="loader" id="toponym-recognition-indicator" style="display:none;"></div>
+          <div id="document-text" style="display:none;">{{ pre_annotated_text | safe }}</div>
         </div>
     </div>
 </div>

--- a/geoparser/annotator/templates/annotate.html
+++ b/geoparser/annotator/templates/annotate.html
@@ -112,8 +112,8 @@
         <div class="col-md-10" id="main-content">
           <div class="col-md-10" id="document-header">
             <h2 class="mt-3" style="text-align:left;float:left;">{{ doc.filename }}</h2>
-            <h2 class="mt-3" style="text-align:left;float:left;font-style:italic;color:#696969" id="toponym-recognition-indicator">toponym recognition in progress...</h2>
           </div>
+          <div class="loader" id="toponym-recognition-indicator"></div>
           <div id="document-text">{{ pre_annotated_text | safe }}</div>
         </div>
     </div>

--- a/geoparser/geoparser/geoparser.py
+++ b/geoparser/geoparser/geoparser.py
@@ -90,7 +90,13 @@ class Geoparser:
 
         spacy.prefer_gpu()
 
-        nlp = spacy.load(spacy_model)
+        # only load spacy model if needed
+        if (
+            not (nlp := getattr(self, "nlp", None))
+            or not isinstance(nlp, spacy.language.Language)
+            or f"{nlp.meta['lang']}_{nlp.meta['name']}" != spacy_model
+        ):
+            nlp = spacy.load(spacy_model)
         nlp.make_doc = lambda text: GeoDoc(
             self,
             nlp.vocab,

--- a/tests/static/annotator_doc0.txt
+++ b/tests/static/annotator_doc0.txt
@@ -1,1 +1,1 @@
-Andorra is a nice place.
+Canada is a nice place.

--- a/tests/static/annotator_doc1.txt
+++ b/tests/static/annotator_doc1.txt
@@ -1,1 +1,1 @@
-I like Andorra.
+I like Canada.

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -54,7 +54,8 @@ def test_get_toponym(annotator: GeoparserAnnotator, query: tuple[int, int]):
         assert result is None
 
 
-def test_parse_files(annotator: GeoparserAnnotator):
+@pytest.mark.parametrize("apply_spacy", [True, False])
+def test_parse_files(annotator: GeoparserAnnotator, apply_spacy: bool):
     model = "en_core_web_sm"
     with open(get_static_test_file("annotator_doc0.txt"), "rb") as doc1, open(
         get_static_test_file("annotator_doc1.txt"), "rb"
@@ -66,6 +67,7 @@ def test_parse_files(annotator: GeoparserAnnotator):
                 for i in range(2)
             ],
             model,
+            apply_spacy,
         )
         assert type(result) is types.GeneratorType
         result = list(result)
@@ -76,12 +78,13 @@ def test_parse_files(annotator: GeoparserAnnotator):
             assert elem["spacy_model"] == model
             documents[i].seek(0)
             assert elem["text"] == documents[i].read().decode("utf-8")
+            n_toponyms = len(elem["toponyms"])
+            assert n_toponyms == 1 if apply_spacy else n_toponyms == 0
             for toponym in elem["toponyms"]:
                 for key in ["text", "start", "end", "loc_id"]:
                     assert key in toponym
                 assert (
-                    elem["text"][toponym["start"] : toponym["end"] + 1]
-                    == toponym["text"]
+                    elem["text"][toponym["start"] : toponym["end"]] == toponym["text"]
                 )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -329,31 +329,6 @@ def test_add_documents(
 
 
 @pytest.mark.parametrize("valid_session", [True, False])
-@pytest.mark.parametrize("loc_id", ["", "123"])
-def test_get_document_progress(client: FlaskClient, valid_session: bool, loc_id: str):
-    session_id = "get_document_progress"
-    toponyms = [{"text": "Andorra", "start": 0, "end": 7, "loc_id": loc_id}]
-    if valid_session:
-        set_session(session_id, toponyms=toponyms)
-    response = client.get(
-        f"/session/{session_id}/document/{0}/progress",
-        content_type="application/json",
-    )
-    if not valid_session:
-        validate_json_response(
-            response, 404, {"error": "Session not found", "status": "error"}
-        )
-    else:
-        expected = {
-            "annotated_toponyms": 0 if not loc_id else 1,
-            "progress_percentage": 0.0 if not loc_id else 100.0,
-            "status": "success",
-            "total_toponyms": 1,
-        }
-        validate_json_response(response, 200, expected)
-
-
-@pytest.mark.parametrize("valid_session", [True, False])
 @pytest.mark.parametrize("doc_index", [0, 1])
 @pytest.mark.parametrize("spacy_applied", [True, False])
 def test_parse_document(
@@ -381,6 +356,31 @@ def test_parse_document(
         # document has been parsed with spacy
         session = sessions_cache.load(session_id)
         assert session["documents"][doc_index]["spacy_applied"] is True
+
+
+@pytest.mark.parametrize("valid_session", [True, False])
+@pytest.mark.parametrize("loc_id", ["", "123"])
+def test_get_document_progress(client: FlaskClient, valid_session: bool, loc_id: str):
+    session_id = "get_document_progress"
+    toponyms = [{"text": "Andorra", "start": 0, "end": 7, "loc_id": loc_id}]
+    if valid_session:
+        set_session(session_id, toponyms=toponyms)
+    response = client.get(
+        f"/session/{session_id}/document/{0}/progress",
+        content_type="application/json",
+    )
+    if not valid_session:
+        validate_json_response(
+            response, 404, {"error": "Session not found", "status": "error"}
+        )
+    else:
+        expected = {
+            "annotated_toponyms": 0 if not loc_id else 1,
+            "progress_percentage": 0.0 if not loc_id else 100.0,
+            "status": "success",
+            "total_toponyms": 1,
+        }
+        validate_json_response(response, 200, expected)
 
 
 @pytest.mark.parametrize("valid_session", [True, False])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -172,6 +172,9 @@ def test_annotate(client: FlaskClient, valid_session: bool, doc_index: int):
     elif valid_session and doc_index == 0:
         assert response.status_code == 200
         assert template.name == "annotate.html"
+        # document has been parsed with spacy
+        session = sessions_cache.load(session_id)
+        assert session["documents"][doc_index]["spacy_applied"] is True
 
 
 def test_create_session(client: FlaskClient):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -75,10 +75,11 @@ def set_session(session_id: str, *, settings=None, **document_kwargs) -> dict:
             "documents": [
                 {
                     "filename": "test.txt",
+                    "spacy_applied": False,
                     "spacy_model": "en_core_web_sm",
                     "text": "Andorra is nice.",
                     "toponyms": [
-                        {"text": "Andorra", "start": 0, "end": 7, "loc_id": ""},
+                        {"end": 7, "loc_id": "", "start": 0, "text": "Andorra"},
                     ],
                 }
             ],
@@ -326,6 +327,23 @@ def test_add_documents(
         )
     else:
         validate_json_response(response, 200, {"status": "success"})
+
+
+@pytest.mark.parametrize("valid_session", [True, False])
+def test_get_documents(client: FlaskClient, valid_session: bool):
+    session_id = "get_documents"
+    if valid_session:
+        session = set_session(session_id)
+    response = client.get(
+        f"/session/{session_id}/documents",
+        content_type="application/json",
+    )
+    if not valid_session:
+        validate_json_response(
+            response, 404, {"message": "Session not found.", "status": "error"}
+        )
+    else:
+        validate_json_response(response, 200, session["documents"])
 
 
 @pytest.mark.parametrize("valid_session", [True, False])


### PR DESCRIPTION
This PR changes the toponym recognition logic of the annotator such that spacy is not run for all documents before the user can start annotating. Instead, the current document is being tagged when loading the annotate page for a specific document. After this, all remaining documents are tagged in the background.

**Changes:**
- Skip spacy when uploading documents
- Do not load the same spacy model again if it is already loaded
- Create a new endpoint `/session/<session_id>/documents` to get all documents of a session
- Create a new endpoint `/session/<session_id>/document/<doc_index>/parse` to run spacy for a specific document
- Call the first endpoint when loading the annotate page for a specific document to get the status of all documents
- Call the second endpoint for the current document if not tagged yet
- After this, sequentially tag all other documents in the background